### PR TITLE
Add 'dingbats' and 'misc symbols' ranges

### DIFF
--- a/ivy-emoji.el
+++ b/ivy-emoji.el
@@ -41,7 +41,7 @@
 ;; The idea of generating the list from code point ranges is taken from the
 ;; no-emoji package
 (defconst ivy-emoji-codepoint-ranges
-  '((#x1f000 . #x1f9ff))
+  '((#x1f000 . #x1f9ff) (#x2600 . #x27bf))
   "List of code point ranges (inclusive) corresponding to all the emojis.")
 
 (defun ivy-emoji--clean-name (name)


### PR DESCRIPTION
This commit adds the https://en.wikipedia.org/wiki/Miscellaneous_Symbols and https://en.wikipedia.org/wiki/Dingbat#Unicode ranges to the scanned ranges, enabling entry of symbols like ✅ and ⛔.